### PR TITLE
:sparkles: Fixed token refresh

### DIFF
--- a/src/actions/actionCreators.js
+++ b/src/actions/actionCreators.js
@@ -54,6 +54,7 @@ export const fetchSpotifyProfilApi = async (configHeaders, dispatch) => {
     dispatch(fetchProfilDataSpotify(result.data));
   } catch (err) {
     console.error('Error to fetch Spotify profile data');
+    window.location.assign(SWITCH_MUSIC_URL);
   }
 };
 
@@ -102,6 +103,7 @@ export const fetchDeezerProfilApi = async (configHeaders, access_token, dispatch
     dispatch(fetchProfilDataDeezer(result.data));
   } catch (err) {
     console.error('Error to fetch Deezer profile data');
+    window.location.assign(SWITCH_MUSIC_URL);
   }
 };
 
@@ -114,3 +116,7 @@ export const fetchDeezerPlaylistApi = async (configHeaders, deezerProfilData, di
     console.error('Error to fetch Deezer playlist data');
   }
 };
+
+export const fetchSpotifySetup = async () => {
+  // https://accounts.spotify.com/api/token
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
       filename: './index.html',
     }),
     new webpack.DefinePlugin({
+      SWITCH_MUSIC_URL: JSON.stringify('http://localhost:8080/switch-music'),
       // Spotify
       SPOTIFY_PROFIL: JSON.stringify('https://api.spotify.com/v1/me'),
       SPOTIFY_PROFIL_PLAYLISTS: JSON.stringify('https://api.spotify.com/v1/me/playlists'),


### PR DESCRIPTION
Fix pour le problème token expires pour les deux API Spotify and Deezer 